### PR TITLE
chore: switch from `jest.spyOn()` to `jest.unstable_mockModule()`

### DIFF
--- a/src/__tests__/fetch-binary.test.ts
+++ b/src/__tests__/fetch-binary.test.ts
@@ -1,48 +1,42 @@
 import os from 'os'
-import { jest } from '@jest/globals'
-import * as cache from '@actions/tool-cache'
-import { fetchBinary } from '../fetch-binary.js'
+import { jest, describe, beforeEach, it, expect } from '@jest/globals'
 
-let platformMock: jest.SpyInstance
-let archMock: jest.SpyInstance
+jest.unstable_mockModule('@actions/tool-cache', () => ({
+  find: jest.fn(),
+  downloadTool: jest.fn(),
+  extractZip: jest.fn(),
+  extractTar: jest.fn(),
+  cacheDir: jest.fn()
+}))
 
-let findMock: jest.SpyInstance
-let downloadToolMock: jest.SpyInstance
-let extractZipMock: jest.SpyInstance
-let extractTarMock: jest.SpyInstance
-let cacheDirMock: jest.SpyInstance
+const cache = await import('@actions/tool-cache')
+const { fetchBinary } = await import('../fetch-binary.js')
 
 describe('fetchBinary', () => {
   beforeEach(() => {
     jest.clearAllMocks()
 
-    platformMock = jest.spyOn(os, 'platform').mockImplementation()
-    archMock = jest.spyOn(os, 'arch').mockImplementation()
-
-    findMock = jest.spyOn(cache, 'find').mockImplementation()
-    downloadToolMock = jest.spyOn(cache, 'downloadTool').mockImplementation()
-    extractZipMock = jest.spyOn(cache, 'extractZip').mockImplementation()
-    extractTarMock = jest.spyOn(cache, 'extractTar').mockImplementation()
-    cacheDirMock = jest.spyOn(cache, 'cacheDir').mockImplementation()
+    jest.spyOn(os, 'platform').mockImplementation()
+    jest.spyOn(os, 'arch').mockImplementation()
   })
 
   it('download linux arm64', async () => {
-    platformMock.mockImplementationOnce(() => 'linux')
-    archMock.mockImplementationOnce(() => 'arm64')
+    jest.spyOn(os, 'platform').mockReturnValueOnce('linux')
+    jest.spyOn(os, 'arch').mockReturnValueOnce('arm64')
 
-    findMock.mockImplementationOnce(() => '')
-    downloadToolMock.mockImplementationOnce(() => '/download/path')
-    extractTarMock.mockImplementationOnce(() => '/extract/path')
-    cacheDirMock.mockImplementationOnce(() => '/cached/path')
+    jest.mocked(cache.find).mockReturnValueOnce('')
+    jest.mocked(cache.downloadTool).mockResolvedValueOnce('/download/path')
+    jest.mocked(cache.extractTar).mockResolvedValueOnce('/extract/path')
+    jest.mocked(cache.cacheDir).mockResolvedValueOnce('/cached/path')
 
     const binaryPath = await fetchBinary('v1.41.1')
 
-    expect(findMock).toHaveBeenCalledWith('hcloud_linux', 'v1.41.1', 'arm64')
-    expect(downloadToolMock).toHaveBeenCalledWith(
+    expect(cache.find).toHaveBeenCalledWith('hcloud_linux', 'v1.41.1', 'arm64')
+    expect(cache.downloadTool).toHaveBeenCalledWith(
       'https://github.com/hetznercloud/cli/releases/download/v1.41.1/hcloud-linux-arm64.tar.gz'
     )
-    expect(extractTarMock).toHaveBeenCalledWith('/download/path')
-    expect(cacheDirMock).toHaveBeenCalledWith(
+    expect(cache.extractTar).toHaveBeenCalledWith('/download/path')
+    expect(cache.cacheDir).toHaveBeenCalledWith(
       '/extract/path',
       'hcloud_linux',
       'v1.41.1',
@@ -53,22 +47,22 @@ describe('fetchBinary', () => {
   })
 
   it('download windows x64', async () => {
-    platformMock.mockImplementationOnce(() => 'win32')
-    archMock.mockImplementationOnce(() => 'x64')
+    jest.spyOn(os, 'platform').mockReturnValueOnce('win32')
+    jest.spyOn(os, 'arch').mockReturnValueOnce('x64')
 
-    findMock.mockImplementationOnce(() => '')
-    downloadToolMock.mockImplementationOnce(() => '/download/path')
-    extractZipMock.mockImplementationOnce(() => '/extract/path')
-    cacheDirMock.mockImplementationOnce(() => '/cached/path')
+    jest.mocked(cache.find).mockReturnValueOnce('')
+    jest.mocked(cache.downloadTool).mockResolvedValueOnce('/download/path')
+    jest.mocked(cache.extractZip).mockResolvedValueOnce('/extract/path')
+    jest.mocked(cache.cacheDir).mockResolvedValueOnce('/cached/path')
 
     const binaryPath = await fetchBinary('v1.41.1')
 
-    expect(findMock).toHaveBeenCalledWith('hcloud_windows', 'v1.41.1', 'amd64')
-    expect(downloadToolMock).toHaveBeenCalledWith(
+    expect(cache.find).toHaveBeenCalledWith('hcloud_windows', 'v1.41.1', 'amd64')
+    expect(cache.downloadTool).toHaveBeenCalledWith(
       'https://github.com/hetznercloud/cli/releases/download/v1.41.1/hcloud-windows-amd64.zip'
     )
-    expect(extractZipMock).toHaveBeenCalledWith('/download/path')
-    expect(cacheDirMock).toHaveBeenCalledWith(
+    expect(cache.extractZip).toHaveBeenCalledWith('/download/path')
+    expect(cache.cacheDir).toHaveBeenCalledWith(
       '/extract/path',
       'hcloud_windows',
       'v1.41.1',
@@ -79,18 +73,18 @@ describe('fetchBinary', () => {
   })
 
   it('download linux arm64 cached', async () => {
-    platformMock.mockImplementationOnce(() => 'linux')
-    archMock.mockImplementationOnce(() => 'arm64')
+    jest.spyOn(os, 'platform').mockReturnValueOnce('linux')
+    jest.spyOn(os, 'arch').mockReturnValueOnce('arm64')
 
-    findMock.mockImplementationOnce(() => '/cached/path')
+    jest.mocked(cache.find).mockReturnValueOnce('/cached/path')
 
     const binaryPath = await fetchBinary('v1.41.1')
 
-    expect(findMock).toHaveBeenCalledWith('hcloud_linux', 'v1.41.1', 'arm64')
+    expect(cache.find).toHaveBeenCalledWith('hcloud_linux', 'v1.41.1', 'arm64')
 
-    expect(downloadToolMock).not.toHaveBeenCalled()
-    expect(extractTarMock).not.toHaveBeenCalled()
-    expect(cacheDirMock).not.toHaveBeenCalled()
+    expect(cache.downloadTool).not.toHaveBeenCalled()
+    expect(cache.extractTar).not.toHaveBeenCalled()
+    expect(cache.cacheDir).not.toHaveBeenCalled()
 
     expect(binaryPath).toEqual('/cached/path')
   })

--- a/src/__tests__/fetch-binary.test.ts
+++ b/src/__tests__/fetch-binary.test.ts
@@ -57,7 +57,11 @@ describe('fetchBinary', () => {
 
     const binaryPath = await fetchBinary('v1.41.1')
 
-    expect(cache.find).toHaveBeenCalledWith('hcloud_windows', 'v1.41.1', 'amd64')
+    expect(cache.find).toHaveBeenCalledWith(
+      'hcloud_windows',
+      'v1.41.1',
+      'amd64'
+    )
     expect(cache.downloadTool).toHaveBeenCalledWith(
       'https://github.com/hetznercloud/cli/releases/download/v1.41.1/hcloud-windows-amd64.zip'
     )

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,18 +1,15 @@
-/**
- * Unit tests for the action's entrypoint, src/index.ts
- */
+import { jest, describe, it, expect } from '@jest/globals'
 
-import { jest } from '@jest/globals'
-import * as main from '../main.js'
+jest.unstable_mockModule('../main.js', () => ({
+  run: jest.fn()
+}))
 
-// Mock the action's entrypoint
-const runMock = jest.spyOn(main, 'run').mockImplementation()
+const { run } = await import('../main.js')
 
 describe('index', () => {
   it('calls run when imported', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    require('../index')
+    await import('../index.js')
 
-    expect(runMock).toHaveBeenCalled()
+    expect(run).toHaveBeenCalled()
   })
 })

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -1,50 +1,41 @@
-/**
- * Unit tests for the action's main functionality, src/main.ts
- *
- * These should be run as if the action was called from a workflow.
- * Specifically, the inputs listed in `action.yml` should be set as environment
- * variables following the pattern `INPUT_<INPUT_NAME>`.
- */
+import { jest, describe, beforeEach, it, expect } from '@jest/globals'
 
-import { jest } from '@jest/globals'
-import * as core from '@actions/core'
-import * as github from '@actions/github'
+jest.unstable_mockModule('../fetch-binary.js', () => ({
+  fetchBinary: jest.fn()
+}))
 
-import * as main from '../main.js'
-import * as fetchBinary from '../fetch-binary.js'
-import * as handleVersion from '../handle-version.js'
+jest.unstable_mockModule('../handle-version.js', () => ({
+  handleVersion: jest.fn()
+}))
 
-const runMock = jest.spyOn(main, 'run')
+jest.unstable_mockModule('@actions/core', () => ({
+  getInput: jest.fn(),
+  addPath: jest.fn(),
+  setOutput: jest.fn(),
+  setFailed: jest.fn()
+}))
 
-let handleVersionMock: jest.SpyInstance
-let fetchBinaryMock: jest.SpyInstance
+jest.unstable_mockModule('@actions/github', () => ({
+  getOctokit: jest.fn()
+}))
 
-let getInputMock: jest.SpyInstance
-let getOctokitMock: jest.SpyInstance
-let addPathMock: jest.SpyInstance
-let setOutputMock: jest.SpyInstance
-let setFailedMock: jest.SpyInstance
+const { run } = await import('../main.js')
+const { fetchBinary } = await import('../fetch-binary.js')
+const { handleVersion } = await import('../handle-version.js')
+const core = await import('@actions/core')
+const github = await import('@actions/github')
 
 describe('action', () => {
   beforeEach(() => {
     jest.clearAllMocks()
 
-    handleVersionMock = jest
-      .spyOn(handleVersion, 'handleVersion')
-      .mockImplementation(async () => 'v1.41.1')
-    fetchBinaryMock = jest
-      .spyOn(fetchBinary, 'fetchBinary')
-      .mockImplementation(async () => '/binary/path')
-
-    getInputMock = jest.spyOn(core, 'getInput').mockImplementation()
-    getOctokitMock = jest.spyOn(github, 'getOctokit').mockImplementation()
-    addPathMock = jest.spyOn(core, 'addPath').mockImplementation()
-    setOutputMock = jest.spyOn(core, 'setOutput').mockImplementation()
-    setFailedMock = jest.spyOn(core, 'setFailed').mockImplementation()
+    jest.mocked(handleVersion).mockResolvedValue('v1.41.1')
+    jest.mocked(fetchBinary).mockResolvedValue('/binary/path')
+    jest.mocked(github.getOctokit).mockReturnValue({} as ReturnType<typeof github.getOctokit>)
   })
 
   it('happy path', async () => {
-    getInputMock.mockImplementation((name: string): string => {
+    jest.mocked(core.getInput).mockImplementation((name: string): string => {
       switch (name) {
         case 'hcloud-version':
           return 'latest'
@@ -55,21 +46,18 @@ describe('action', () => {
       }
     })
 
-    getOctokitMock.mockImplementationOnce(() => null)
+    await run()
 
-    await main.run()
-    expect(runMock).toHaveReturned()
-    expect(setFailedMock).not.toHaveBeenCalled()
-
-    expect(getOctokitMock).toHaveBeenCalled()
-    expect(handleVersionMock).toHaveBeenCalled()
-    expect(fetchBinaryMock).toHaveBeenCalledWith('v1.41.1')
-    expect(addPathMock).toHaveBeenCalledWith('/binary/path')
-    expect(setOutputMock).toHaveBeenCalledWith('hcloud-version', 'v1.41.1')
+    expect(core.setFailed).not.toHaveBeenCalled()
+    expect(github.getOctokit).toHaveBeenCalled()
+    expect(handleVersion).toHaveBeenCalled()
+    expect(fetchBinary).toHaveBeenCalledWith('v1.41.1')
+    expect(core.addPath).toHaveBeenCalledWith('/binary/path')
+    expect(core.setOutput).toHaveBeenCalledWith('hcloud-version', 'v1.41.1')
   })
 
   it('failed', async () => {
-    getInputMock.mockImplementation((name: string): string => {
+    jest.mocked(core.getInput).mockImplementation((name: string): string => {
       switch (name) {
         case 'hcloud-version':
           return 'latest'
@@ -80,14 +68,10 @@ describe('action', () => {
       }
     })
 
-    getOctokitMock.mockImplementationOnce(() => null)
-    handleVersionMock.mockImplementation(async () => {
-      throw new Error('some error occurred')
-    })
+    jest.mocked(handleVersion).mockRejectedValueOnce(new Error('some error occurred'))
 
-    await main.run()
-    expect(runMock).toHaveReturned()
+    await run()
 
-    expect(setFailedMock).toHaveBeenCalledWith('some error occurred')
+    expect(core.setFailed).toHaveBeenCalledWith('some error occurred')
   })
 })

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -31,7 +31,9 @@ describe('action', () => {
 
     jest.mocked(handleVersion).mockResolvedValue('v1.41.1')
     jest.mocked(fetchBinary).mockResolvedValue('/binary/path')
-    jest.mocked(github.getOctokit).mockReturnValue({} as ReturnType<typeof github.getOctokit>)
+    jest
+      .mocked(github.getOctokit)
+      .mockReturnValue({} as ReturnType<typeof github.getOctokit>)
   })
 
   it('happy path', async () => {
@@ -68,7 +70,9 @@ describe('action', () => {
       }
     })
 
-    jest.mocked(handleVersion).mockRejectedValueOnce(new Error('some error occurred'))
+    jest
+      .mocked(handleVersion)
+      .mockRejectedValueOnce(new Error('some error occurred'))
 
     await run()
 


### PR DESCRIPTION
The fix was switching from `jest.spyOn()` to `jest.unstable_mockModule()` with dynamic `await import()`. In ESM, namespace module exports are read-only, so `jest.spyOn` can’t replace them. The `jest.unstable_mockModule()` approach intercepts module resolution at the Jest level, which works correctly with ESM.

https://jestjs.io/docs/ecmascript-modules