### PR TITLE
ci: add npm audit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,21 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm audit
+
   test-action:
     runs-on: ${{ matrix.runs-on }}
 


### PR DESCRIPTION
Ensure we do not use packages that have known vulnerabilities.